### PR TITLE
Add replication smoke test + GitHub Actions CI

### DIFF
--- a/.github/workflows/replication-smoke.yml
+++ b/.github/workflows/replication-smoke.yml
@@ -1,0 +1,53 @@
+name: replication-smoke
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcurl4-openssl-dev \
+            libssl-dev \
+            libxml2-dev
+
+      - name: Install R packages
+        run: |
+          Rscript -e 'pkgs <- c("here","data.table","dplyr","boot","mhurdle","jsonlite","tidyr","tibble"); install.packages(pkgs); ok <- pkgs %in% rownames(installed.packages()); if (!all(ok)) { cat("Failed to install:", paste(pkgs[!ok], collapse=", "), "\n"); quit(status = 1L) }'
+
+      - name: Run replication smoke test
+        run: |
+          Rscript "Econometrics/smoke_test.R"
+
+  python-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      # Stdlib-only smoke test: compiles every .py and validates shipped data
+      # artifacts. No pip install — it imports nothing outside the standard
+      # library and deliberately does NOT run the torch/GPU classifier pipeline.
+      - name: Run Python replication smoke test
+        run: |
+          python "Climate finance estimation/smoke_test.py"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 .RData
 __pycache__/
 *.pyc
+
+# Smoke-test transients (regenerated locally; Data.zip is the shipped artifact)
+Econometrics/Data/reg*.csv
+Econometrics/regressions/common_support/cells_C_*.rds

--- a/Climate finance estimation/smoke_test.py
+++ b/Climate finance estimation/smoke_test.py
@@ -1,0 +1,273 @@
+# =============================================================================
+# Climate finance estimation/smoke_test.py
+# -----------------------------------------------------------------------------
+# Purpose
+#   Clone-runnable, LIGHT smoke test for the Python side of the UNDERCANOPY
+#   replication package (the ClimateFinanceBERT pipeline under
+#   "Training and Classifying/" and "Figures/graph_final.py").
+#
+# Why this test is deliberately light (and does NOT run the pipeline)
+#   The actual pipeline needs torch + transformers + a GPU + the trained model
+#   weights to run. None of that exists in CI (no GPU, no multi-GB weights, no
+#   heavy deps). So we CANNOT execute the classifier here. Instead we validate
+#   the two things that ARE light and clone-runnable:
+#     (1) every shipped .py source compiles (syntax-level, via py_compile), and
+#     (2) the shipped data artifacts are present and internally consistent.
+#   This catches the most common breakages (a syntax slip on push, a corrupted
+#   or out-of-sync data file) without any of the heavy machinery.
+#
+# Dependencies
+#   Python 3 STDLIB ONLY: os, sys, json, csv, py_compile, glob.
+#   No torch, no pandas, no transformers, no network, no GPU.
+#
+# What it checks
+#   1. compile_all : every "*.py" under this directory (recursive), excluding
+#                    this smoke_test.py, compiles with py_compile (doraise).
+#   2. json_dicts  : dictionary_classes.json and reverse_dictionary_classes.json
+#                    are non-empty and exact mutual inverses (same length).
+#   3. train_set   : train_set.csv is semicolon-delimited with header
+#                    text;label;relevance and has parseable data rows (HARD
+#                    assertions). Label/dictionary coverage is reported as a
+#                    NON-FATAL WARNING only -- see step 3 rationale below.
+#
+# Exit codes
+#   0 -> all steps OK; prints "PY SMOKE TEST: PASS".
+#   1 -> any step FAILED; prints "PY SMOKE TEST: FAIL".
+#   Suitable as a CI gate.
+# =============================================================================
+
+import os
+import sys
+import json
+import csv
+import py_compile
+import glob
+
+# Resolve everything relative to THIS file so the test runs from any CWD.
+HERE = os.path.dirname(os.path.abspath(__file__))
+DATA = os.path.join(HERE, "Data")
+
+DICT_PATH = os.path.join(DATA, "dictionary_classes.json")
+REVERSE_DICT_PATH = os.path.join(DATA, "reverse_dictionary_classes.json")
+TRAIN_SET_PATH = os.path.join(DATA, "train_set.csv")
+
+# -----------------------------------------------------------------------------
+# Status accumulation + step wrapper (mirrors the R smoke_test.R structure).
+# -----------------------------------------------------------------------------
+_step_names = []
+_step_status = []  # "OK" or "FAIL"
+
+
+def run_step(name, fn):
+  """Run fn() inside a try/except, record OK/FAIL, and report the message."""
+  try:
+    fn()
+    _step_names.append(name)
+    _step_status.append("OK")
+  except Exception as exc:  # noqa: BLE001 - we want every failure logged, not raised
+    print("[FAIL] {}: {}".format(name, exc))
+    _step_names.append(name)
+    _step_status.append("FAIL")
+
+
+# =============================================================================
+# Step 1 — Every shipped .py compiles (syntax-level).
+# =============================================================================
+def step_compile_all():
+  pattern = os.path.join(HERE, "**", "*.py")
+  py_files = sorted(glob.glob(pattern, recursive=True))
+
+  # Exclude this smoke test itself.
+  self_path = os.path.abspath(__file__)
+  py_files = [p for p in py_files if os.path.abspath(p) != self_path]
+
+  if len(py_files) < 1:
+    raise AssertionError("no .py files found to compile under {}".format(HERE))
+
+  failures = []
+  for path in py_files:
+    try:
+      py_compile.compile(path, doraise=True)
+    except py_compile.PyCompileError as exc:
+      failures.append("{}: {}".format(os.path.relpath(path, HERE), exc.msg))
+
+  if failures:
+    raise AssertionError(
+      "compile error(s) in {} file(s):\n  - {}".format(
+        len(failures), "\n  - ".join(failures)
+      )
+    )
+
+  print("  compiled {} .py file(s) OK".format(len(py_files)))
+
+
+# =============================================================================
+# Step 2 — Forward / reverse class dictionaries are exact mutual inverses.
+# =============================================================================
+def step_json_dicts():
+  with open(DICT_PATH, "r", encoding="utf-8") as fh:
+    forward = json.load(fh)
+  with open(REVERSE_DICT_PATH, "r", encoding="utf-8") as fh:
+    reverse = json.load(fh)
+
+  if not isinstance(forward, dict) or len(forward) == 0:
+    raise AssertionError("dictionary_classes.json is not a non-empty dict")
+  if not isinstance(reverse, dict) or len(reverse) == 0:
+    raise AssertionError("reverse_dictionary_classes.json is not a non-empty dict")
+
+  if len(forward) != len(reverse):
+    raise AssertionError(
+      "length mismatch: forward={}, reverse={}".format(len(forward), len(reverse))
+    )
+
+  for name, idx in forward.items():
+    key = str(idx)
+    if key not in reverse:
+      raise AssertionError(
+        "forward id {!r} (class {!r}) missing as key in reverse dict".format(idx, name)
+      )
+    if reverse[key] != name:
+      raise AssertionError(
+        "inverse mismatch at id {!r}: reverse={!r} != forward name {!r}".format(
+          idx, reverse[key], name
+        )
+      )
+
+  print("  forward/reverse dicts are exact inverses; {} classes".format(len(forward)))
+
+
+# =============================================================================
+# Step 3 — train_set.csv structure (HARD) + label/dict coverage (WARNING ONLY).
+#
+# Self-contained: reloads the forward dict inside its own try so a step-2
+# failure does not cascade into a confusing step-3 error.
+#
+# WHY label-coverage is a WARNING, not a failure:
+#   multi-classifier.py builds its label dictionary DYNAMICALLY at train time
+#   from df[df.relevance==1]['label'].unique() and then WRITES out
+#   dictionary_classes.json / reverse_dictionary_classes.json from that. So the
+#   shipped dictionary_classes.json is an OUTPUT ARTIFACT, not a training INPUT:
+#   the pipeline regenerates it from train_set.csv and never consumes the shipped
+#   copy. A drift between the shipped dict and the shipped train_set labels does
+#   NOT break replication -- it is a stale-artifact diagnostic. We therefore
+#   surface it for maintainer attention but do not block the suite.
+#
+# HARD assertions (step FAILs -> exit 1):
+#   file opens, header is exactly ["text","label","relevance"], >0 data rows,
+#   relevance values parse as float.
+# =============================================================================
+def step_train_set():
+  with open(DICT_PATH, "r", encoding="utf-8") as fh:
+    forward = json.load(fh)
+  valid_labels = set(forward.keys())
+
+  expected_header = ["text", "label", "relevance"]
+  n_total = 0
+  n_pos = 0
+  n_neg = 0
+  missing_labels = set()       # relevance==1 labels absent from the shipped dict
+  seen_pos_labels = set()      # all relevance==1 labels actually observed
+
+  # HARD: file must open.
+  with open(TRAIN_SET_PATH, "r", encoding="utf-8", newline="") as fh:
+    reader = csv.reader(fh, delimiter=";")
+    try:
+      header = next(reader)
+    except StopIteration:
+      raise AssertionError("train_set.csv is empty (no header)")
+
+    # HARD: header must be exactly the expected three columns.
+    if header != expected_header:
+      raise AssertionError(
+        "unexpected header: {!r} (expected {!r})".format(header, expected_header)
+      )
+
+    for row in reader:
+      if len(row) < 3:
+        # Skip blank trailing lines; flag genuinely malformed rows.
+        if not any(cell.strip() for cell in row):
+          continue
+        raise AssertionError("malformed row with < 3 fields: {!r}".format(row))
+
+      n_total += 1
+      label = row[1]
+      # HARD: relevance must parse as float.
+      try:
+        relevance = float(row[2])
+      except ValueError:
+        raise AssertionError(
+          "non-numeric relevance {!r} in row {!r}".format(row[2], row)
+        )
+
+      if relevance == 1.0:
+        n_pos += 1
+        seen_pos_labels.add(label)
+        if label not in valid_labels:
+          missing_labels.add(label)
+      elif relevance == 0.0:
+        n_neg += 1
+      else:
+        raise AssertionError("unexpected relevance value {!r}".format(relevance))
+
+  # HARD: there must be at least one data row.
+  if n_total < 1:
+    raise AssertionError("train_set.csv has no data rows")
+
+  # Always report the row counts.
+  print(
+    "  train_set.csv OK: {} rows ({} relevance==1, {} relevance==0)".format(
+      n_total, n_pos, n_neg
+    )
+  )
+
+  # NON-FATAL: label/dict coverage drift. multi-classifier.py rebuilds the dict
+  # from train_set.csv (df['label'].unique()), so the shipped dict is an output
+  # artifact, not a training input; this drift does not block replication.
+  if missing_labels:
+    sample = sorted(missing_labels)[:10]
+    print(
+      "  [WARN] train_set: {} relevance==1 label(s) not found in "
+      "dictionary_classes.json (dict is regenerated by multi-classifier.py from "
+      "train_set, so this is non-fatal drift): {}".format(
+        len(missing_labels), ", ".join(repr(s) for s in sample)
+      )
+    )
+
+  unused_keys = valid_labels - seen_pos_labels
+  if unused_keys:
+    sample = sorted(unused_keys)[:10]
+    print(
+      "  [WARN] train_set: {} dictionary_classes.json key(s) never appear as a "
+      "relevance==1 label: {}".format(
+        len(unused_keys), ", ".join(repr(s) for s in sample)
+      )
+    )
+
+
+# =============================================================================
+# Run all steps, print summary table, exit with appropriate status.
+# =============================================================================
+def main():
+  run_step("compile_all", step_compile_all)
+  run_step("json_dicts", step_json_dicts)
+  run_step("train_set", step_train_set)
+
+  bar = "=" * 50
+  print("\n" + bar)
+  print("PYTHON REPLICATION SMOKE TEST - SUMMARY")
+  print(bar)
+  width = max(len(n) for n in _step_names)
+  for name, status in zip(_step_names, _step_status):
+    print("  {:<{w}}  {}".format(name, status, w=width))
+  print(bar)
+
+  if "FAIL" in _step_status:
+    print("PY SMOKE TEST: FAIL")
+    sys.exit(1)
+  else:
+    print("PY SMOKE TEST: PASS")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+  main()

--- a/Econometrics/Identification/identification_aipw.R
+++ b/Econometrics/Identification/identification_aipw.R
@@ -26,7 +26,8 @@ out_dir <- here::here("Econometrics", "regressions", "aipw")
 dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
 
 t0 <- Sys.time()
-N_BOOT <- 300L                        # production setting per task spec
+N_BOOT <- as.integer(Sys.getenv("UC_N_BOOT", unset = "300"))                        # production setting per task spec
+stopifnot(!is.na(N_BOOT), N_BOOT >= 1L)   # guard against a malformed UC_N_BOOT override
 TRIM_GRID <- list(
   c(0.01, 0.99),
   c(0.05, 0.95),

--- a/Econometrics/Identification/identification_aipw_h1.R
+++ b/Econometrics/Identification/identification_aipw_h1.R
@@ -27,7 +27,8 @@ out_dir <- here::here("Econometrics", "regressions", "aipw_h1")
 dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
 
 t0 <- Sys.time()
-N_BOOT <- 100L
+N_BOOT <- as.integer(Sys.getenv("UC_N_BOOT", unset = "100"))
+stopifnot(!is.na(N_BOOT), N_BOOT >= 1L)   # guard against a malformed UC_N_BOOT override
 TRIM_GRID <- list(c(0.01, 0.99), c(0.05, 0.95), c(0.10, 0.90))
 APE_VARS <- EXPANDED_COVARS
 EPS_PROB_LOCAL <- 1e-12

--- a/Econometrics/Identification/identification_lee_bounds.R
+++ b/Econometrics/Identification/identification_lee_bounds.R
@@ -26,7 +26,8 @@ out_dir <- here::here("Econometrics", "regressions", "lee_bounds")
 dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
 
 t0 <- Sys.time()
-N_BOOT <- 300L
+N_BOOT <- as.integer(Sys.getenv("UC_N_BOOT", unset = "300"))
+stopifnot(!is.na(N_BOOT), N_BOOT >= 1L)   # guard against a malformed UC_N_BOOT override
 # Expanded coverage 2026-05-04: every variable that changes sign or
 # significance between Han / Rio / BERT in §4 of the EARE Round-1 revision.
 COEFS <- EXPANDED_COVARS

--- a/Econometrics/Identification/identification_lee_bounds_h1.R
+++ b/Econometrics/Identification/identification_lee_bounds_h1.R
@@ -32,7 +32,8 @@ out_dir <- here::here("Econometrics", "regressions", "lee_bounds_h1")
 dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
 
 t0 <- Sys.time()
-N_BOOT <- 100L
+N_BOOT <- as.integer(Sys.getenv("UC_N_BOOT", unset = "100"))
+stopifnot(!is.na(N_BOOT), N_BOOT >= 1L)   # guard against a malformed UC_N_BOOT override
 COEFS <- EXPANDED_COVARS
 COEFS_BINARY <- EXPANDED_COVARS_BINARY
 COEFS_CONTINUOUS <- EXPANDED_COVARS_CONTINUOUS

--- a/Econometrics/Identification/marginal_effects_ape.R
+++ b/Econometrics/Identification/marginal_effects_ape.R
@@ -63,7 +63,8 @@ dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
 t0 <- Sys.time()
 
 # ── Constants ────────────────────────────────────────────────────────────────
-N_BOOT <- 300L                   # FIX 3 — production target.
+N_BOOT <- as.integer(Sys.getenv("UC_N_BOOT", unset = "300"))   # FIX 3 — production target.
+stopifnot(!is.na(N_BOOT), N_BOOT >= 1L)   # guard against a malformed UC_N_BOOT override
 N_BOOT_FALLBACK <- 200L          # If 300-rep budget overruns we drop to this.
 WALL_CLOCK_BUDGET_SEC <- 3 * 3600  # 3 hours total
 MIN_FE_CELLS <- 30L              # Drop FE dummies with <30 obs in either margin

--- a/Econometrics/smoke_test.R
+++ b/Econometrics/smoke_test.R
@@ -1,0 +1,223 @@
+# =============================================================================
+# Econometrics/smoke_test.R
+# -----------------------------------------------------------------------------
+# Purpose
+#   Clone-runnable replication smoke test for the UNDERCANOPY package. Confirms
+#   that a fresh checkout can: (a) unpack the shipped data, (b) run the variable
+#   selection step end-to-end, and (c) run the lightest identification script
+#   (common-support hurdle) end-to-end, producing the expected output files.
+#
+# What it runs (and ONLY this — it is deliberately light)
+#   1. Unzip Econometrics/Data/Data.zip (skipped if reg1.csv already present).
+#   2. select_variables.R  -> regressions/var_selection/{...}
+#   3. identification_common_support.R -> regressions/common_support/{...}
+#
+# Data
+#   Uses ONLY data shipped inside the repo (Econometrics/Data/Data.zip). No
+#   external drive, no network, no GPU. The six top-level CSVs in the zip
+#   (reg1/2/3 and their _mitigation counterparts) are everything these two
+#   steps need.
+#
+# Bootstrap override
+#   Sys.setenv(UC_N_BOOT = "5") is set so that any script honouring the
+#   UC_N_BOOT env-var (the AIPW / Lee-bounds / APE scripts) would bootstrap
+#   tiny. The common-support step itself does NOT bootstrap; the override is
+#   set here for completeness and to document the hook for anyone extending
+#   this smoke test to the heavier identification scripts.
+#
+# Exit status
+#   Prints a PASS/FAIL table over the steps. Any failed step or missing/empty
+#   output file -> quit(status = 1L). Full success -> "SMOKE TEST: PASS" and
+#   quit(status = 0L). Suitable as a CI gate.
+#
+# Side effect (local runs)
+#   To make the assertions an HONEST fresh-generation check, the test deletes
+#   the 8 expected outputs before regenerating them. Running it locally will
+#   therefore show the committed regressions/var_selection/* and
+#   regressions/common_support/* tables as modified afterwards (cosmetic: a UTC
+#   timestamp in var_selection; mhurdle is mildly run-sensitive in
+#   common_support). Discard these with `git checkout -- Econometrics/regressions`.
+#   In CI the checkout is ephemeral, so this is a non-issue there.
+# =============================================================================
+
+suppressPackageStartupMessages({
+  library(here)
+  library(data.table)
+  library(dplyr)
+  library(jsonlite)
+})
+
+# .git at the repo root lets here() resolve to the repo root from anywhere.
+ROOT <- here::here()
+
+# Honour the bootstrap override hook (tiny). See header note.
+Sys.setenv(UC_N_BOOT = "5")
+
+# -----------------------------------------------------------------------------
+# Status accumulation helpers.
+# -----------------------------------------------------------------------------
+step_names  <- character(0)
+step_status <- character(0)   # "OK" or "FAIL"
+
+record_step <- function(name, ok) {
+  step_names  <<- c(step_names, name)
+  step_status <<- c(step_status, if (isTRUE(ok)) "OK" else "FAIL")
+  invisible(ok)
+}
+
+# A step wrapper that reports the step name + condition message rather than
+# aborting silently. Warnings are handled with withCallingHandlers (which does
+# NOT unwind the call stack) so a benign warning fired mid-script does not abort
+# the rest of `expr` — we log it and invokeRestart("muffleWarning") to resume
+# exactly where the warning fired. Only ERRORS (caught by the surrounding
+# tryCatch) mark a step FAIL. This mirrors a plain source(), where warnings do
+# not unwind; a `warning = ...` handler in tryCatch would unwind and produce a
+# false PASS by skipping the remainder of the step.
+run_step <- function(name, expr) {
+  ok <- tryCatch(
+    withCallingHandlers(
+      {
+        force(expr)
+        TRUE
+      },
+      warning = function(w) {
+        message(sprintf("[WARN] %s: %s", name, conditionMessage(w)))
+        invokeRestart("muffleWarning")
+      }
+    ),
+    error = function(e) {
+      message(sprintf("[FAIL] %s: %s", name, conditionMessage(e)))
+      FALSE
+    }
+  )
+  record_step(name, ok)
+}
+
+# Non-empty-file checker.
+file_ok <- function(p) file.exists(p) && isTRUE(file.info(p)$size > 0)
+
+# -----------------------------------------------------------------------------
+# Expected GENERATED outputs (defined once, reused by cleanup + assertions).
+#
+# These are all regenerated artifacts of steps 2-3 — three from var_selection
+# and five from common_support. They are committed in the repo, so unless we
+# delete them first, a step that silently fails to (re)write its output would
+# still pass the assertions: a stale-file false PASS. We therefore unlink them
+# BEFORE the steps run, forcing the smoke test to verify FRESH generation.
+#
+# NOTE: the unzipped reg*.csv files are INPUTS, not outputs — they are NOT in
+# this vector and must NOT be deleted.
+# -----------------------------------------------------------------------------
+EXPECTED <- c(
+  file.path(ROOT, "Econometrics", "regressions", "var_selection",
+            "selection_diagnostic.csv"),
+  file.path(ROOT, "Econometrics", "regressions", "var_selection",
+            "selected_variables.json"),
+  file.path(ROOT, "Econometrics", "regressions", "var_selection",
+            "selection_summary.txt"),
+  file.path(ROOT, "Econometrics", "regressions", "common_support",
+            "coef_adapt.csv"),
+  file.path(ROOT, "Econometrics", "regressions", "common_support",
+            "coef_miti.csv"),
+  file.path(ROOT, "Econometrics", "regressions", "common_support",
+            "cells_C_adapt.rds"),
+  file.path(ROOT, "Econometrics", "regressions", "common_support",
+            "cells_C_miti.rds"),
+  file.path(ROOT, "Econometrics", "regressions", "common_support",
+            "summary.rds")
+)
+
+# Delete any pre-existing generated outputs so the assertions step verifies
+# fresh generation rather than committed stale files. Done BEFORE steps 2-3
+# (and after the unzip step is defined; the actual unzip runs below). The
+# unzipped CSV inputs are deliberately left untouched.
+unlink(EXPECTED[file.exists(EXPECTED)])
+
+# =============================================================================
+# Step 1 — Unzip shipped data (only if reg1.csv is absent).
+# =============================================================================
+run_step("unzip_data", {
+  data_dir <- file.path(ROOT, "Econometrics", "Data")
+  reg1     <- file.path(data_dir, "reg1.csv")
+  if (!file.exists(reg1)) {
+    zip <- file.path(data_dir, "Data.zip")
+    if (!file.exists(zip)) {
+      stop(sprintf("Data archive not found: %s", zip))
+    }
+    utils::unzip(zip, exdir = data_dir)
+  }
+  if (!file.exists(reg1)) {
+    stop("reg1.csv still absent after unzip attempt")
+  }
+})
+
+# =============================================================================
+# Step 2 — Variable selection, end-to-end.
+#
+# select_variables.R guards its wrapper with `if (sys.nframe() == 0L)`, which is
+# FALSE when sourced. We therefore source the file (to define the functions)
+# and then CALL select_variables() ourselves with the project default inputs.
+# =============================================================================
+run_step("select_variables", {
+  source(file.path(ROOT, "Econometrics", "select_variables.R"))
+
+  main_dir <- file.path(ROOT, "Econometrics", "regressions", "main")
+  out_dir  <- file.path(ROOT, "Econometrics", "regressions", "var_selection")
+
+  select_variables(
+    adapt_han_path  = file.path(main_dir, "adaptation", "combined_regression_results.csv"),
+    adapt_bert_path = file.path(main_dir, "adaptation", "combined_regression_results3.csv"),
+    miti_han_path   = file.path(main_dir, "mitigation", "combined_regression_results.csv"),
+    miti_bert_path  = file.path(main_dir, "mitigation", "combined_regression_results3.csv"),
+    alpha           = 0.05,
+    out_dir         = out_dir
+  )
+  invisible(NULL)
+})
+
+# =============================================================================
+# Step 3 — Common-support identification script, end-to-end.
+#
+# This script has no sys.nframe guard: sourcing executes it fully. It reads the
+# six reg CSVs, fits dyad-year hurdles (mhurdle, with a probit/OLS fallback),
+# and writes its outputs. It is the lightest identification script — no
+# bootstrap.
+# =============================================================================
+run_step("common_support", {
+  source(file.path(ROOT, "Econometrics", "Identification",
+                   "identification_common_support.R"))
+  invisible(NULL)
+})
+
+# =============================================================================
+# Step 4 — Assert expected outputs exist and are non-empty.
+# =============================================================================
+run_step("assertions", {
+  # Reuse the EXPECTED vector defined near the top; these were unlinked before
+  # the steps ran, so their presence here proves fresh generation.
+  missing_or_empty <- EXPECTED[!vapply(EXPECTED, file_ok, logical(1))]
+  if (length(missing_or_empty) > 0L) {
+    stop(sprintf("Missing or empty output file(s):\n  - %s",
+                 paste(missing_or_empty, collapse = "\n  - ")))
+  }
+})
+
+# =============================================================================
+# Summary table + exit status.
+# =============================================================================
+cat("\n", strrep("=", 50), "\n", sep = "")
+cat("REPLICATION SMOKE TEST — SUMMARY\n")
+cat(strrep("=", 50), "\n", sep = "")
+width <- max(nchar(step_names))
+for (i in seq_along(step_names)) {
+  cat(sprintf("  %-*s  %s\n", width, step_names[i], step_status[i]))
+}
+cat(strrep("=", 50), "\n", sep = "")
+
+if (any(step_status == "FAIL")) {
+  cat("SMOKE TEST: FAIL\n")
+  quit(status = 1L)
+} else {
+  cat("SMOKE TEST: PASS\n")
+  quit(status = 0L)
+}


### PR DESCRIPTION
Make the package self-verifying on a fresh clone, using only shipped data (no external drive, no GPU, no model weights).

Econometrics (R):
- smoke_test.R: unzip Data.zip if absent, set UC_N_BOOT=5, delete-then- regenerate the 8 expected outputs (honest fresh-generation check), run select_variables.R and identification_common_support.R end-to-end, assert outputs non-empty, PASS/FAIL table, quit(1) on any failure. run_step muffles benign mhurdle warnings via withCallingHandlers (a tryCatch warning handler would unwind and abort the script).
- UC_N_BOOT env override on the five bootstrapping identification scripts (aipw, aipw_h1, lee_bounds, lee_bounds_h1, marginal_effects_ape); per-file production defaults preserved (300/100/300/100/300), guarded with stopifnot.

Climate finance estimation (Python):
- smoke_test.py: stdlib-only; py_compile every script, verify the two class dictionaries are mutual inverses, validate train_set.csv structure. Label/dict drift is a non-fatal warning (multi-classifier.py rebuilds the dict from the train set, so the shipped dict is an output artifact, not a training input).

CI: .github/workflows/replication-smoke.yml runs both smoke tests on push/pull_request (parallel jobs); R install step fails the build on a missing package. .gitignore: unzipped reg*.csv and regenerated cells_C_*.rds.